### PR TITLE
PRO-2297: chore: add PR validation workflow

### DIFF
--- a/.github/workflows/pr-validation.yaml
+++ b/.github/workflows/pr-validation.yaml
@@ -1,0 +1,11 @@
+name: PR Validation
+on:
+  pull_request:
+    types: [opened, edited, synchronize, reopened]
+
+jobs:
+  validate-pr-title:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: releaseband/cicd/.github/actions/valide-pr-title@main


### PR DESCRIPTION
## Summary

Adds `.github/workflows/pr-validation.yaml` so every PR in this repo is checked against the org-wide PR-title convention (`TICKET-123: description`, projects PRO / GAMES / RD).

Tracked in [PRO-2297](https://gamebeat.atlassian.net/browse/PRO-2297).

Opened automatically by `devops-tools/rollout-pr-validation`.


[PRO-2297]: https://gamebeat.atlassian.net/browse/PRO-2297?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ